### PR TITLE
Various Cosmetic Updates

### DIFF
--- a/src/ev_q_definitions.lua
+++ b/src/ev_q_definitions.lua
@@ -14,6 +14,7 @@ g.defineEvent("populateTokenPool")
 
 g.defineEvent("tokenDraw")
 
+g.defineEvent("tokenHitStart")
 g.defineEvent("tokenHit")
 g.defineEvent("tokenDamaged")
 g.defineEvent("tokenDestroyed")

--- a/src/g.lua
+++ b/src/g.lua
@@ -240,13 +240,26 @@ local nameToQuad = {--[[
 ---@param kx number?
 ---@param ky number?
 function g.drawImage(imageName, x,y, r,sx,sy,kx,ky)
+    return g.drawImageOffset(imageName, x, y, r, sx, sy, 0.5, 0.5, kx, ky)
+end
+
+---@param imageName string
+---@param x number
+---@param y number
+---@param r number?
+---@param sx number?
+---@param sy number?
+---@param ox number?
+---@param oy number?
+---@param kx number?
+---@param ky number?
+function g.drawImageOffset(imageName, x,y, r, sx,sy, ox,oy, kx,ky)
     local quad = nameToQuad[imageName]
     if not quad then
         error("Invalid quad: "..tostring(imageName))
     end
     local _,_,w,h = quad:getViewport()
-    local ox,oy = w/2,h/2
-    atlas:draw(quad,x,y,r,sx,sy,ox,oy,kx,ky)
+    atlas:draw(quad, x, y, r, sx, sy, ox * w, oy * h, kx, ky)
 end
 
 

--- a/src/g.lua
+++ b/src/g.lua
@@ -374,6 +374,7 @@ g.stats.BoneLimit = g.defineStat("BoneLimit", 1000)
 
 ---@alias g.Resources {money: number, bones: number, rocks: number, logs: number}
 
+---@alias g.ResourceType "money"|"logs"|"rocks"|"bones"
 
 ---@alias g.PrestigeRange {lower: integer, upper: integer}
 
@@ -454,10 +455,15 @@ function g.getLogs()
     return currentSession.resources.logs
 end
 
-
 ---@return g.Resources
 function g.getResources()
     return currentSession.resources
+end
+
+---@param restype g.ResourceType
+---@return number
+function g.getResource(restype)
+    return (assert(currentSession.resources[restype], "invalid resource type"))
 end
 
 

--- a/src/g.lua
+++ b/src/g.lua
@@ -641,7 +641,8 @@ end
 ---@field maxHealth number
 ---@field image string
 ---@field resources g.Bundle
----@field timeSinceHitStart number
+---@field timeSinceHitStart number Time since last `tryHitToken` is initiated (it's not immediately hit).
+---@field timeSinceHit number Time since `tryHitToken` actually hits the token.
 ---@field timeSinceDamaged number
 ---@field timeAlive number
 ---
@@ -693,6 +694,7 @@ function g.spawnToken(tokType, x,y)
 
         timeAlive = 0,
         timeSinceHitStart = 0xffffffffff,
+        timeSinceHit = 0xffffffffff,
         timeSinceDamaged = 0xfffffffff,
     }, tokenMts[tokType])
 

--- a/src/g.lua
+++ b/src/g.lua
@@ -756,10 +756,8 @@ end
 function g.tryHitToken(tok)
     local time = tok.timeSinceHitStart
     if time > g.stats.HitDuration then
-        local hitMult = g.ask("getTokenHitMultiplier", tok)
-        g.damageToken(tok, hitMult * g.stats.HitDamage)
-        g.call("tokenHit", tok)
         tok.timeSinceHitStart = 0
+        g.call("tokenHitStart", tok)
     end
 end
 

--- a/src/g.lua
+++ b/src/g.lua
@@ -641,7 +641,7 @@ end
 ---@field maxHealth number
 ---@field image string
 ---@field resources g.Bundle
----@field timeSinceHit number
+---@field timeSinceHitStart number
 ---@field timeSinceDamaged number
 ---@field timeAlive number
 ---
@@ -692,7 +692,7 @@ function g.spawnToken(tokType, x,y)
         id = currentTokenId,
 
         timeAlive = 0,
-        timeSinceHit = 0xffffffffff,
+        timeSinceHitStart = 0xffffffffff,
         timeSinceDamaged = 0xfffffffff,
     }, tokenMts[tokType])
 
@@ -754,12 +754,12 @@ end
 
 ---@param tok g.Token
 function g.tryHitToken(tok)
-    local time = tok.timeSinceHit
+    local time = tok.timeSinceHitStart
     if time > g.stats.HitDuration then
         local hitMult = g.ask("getTokenHitMultiplier", tok)
         g.damageToken(tok, hitMult * g.stats.HitDamage)
         g.call("tokenHit", tok)
-        tok.timeSinceHit = 0
+        tok.timeSinceHitStart = 0
     end
 end
 

--- a/src/ui/hud/hud.lua
+++ b/src/ui/hud/hud.lua
@@ -39,7 +39,7 @@ function HUD:drawResourceHUD(camera)
     return self.resourceHUD:draw(camera)
 end
 
----@param kind g.hud._ResourceKind
+---@param kind g.ResourceType
 ---@param x number Position of the token in world-space.
 ---@param y number Position of the token in world-space.
 ---@param amount number Amount to add to the display once it's done.

--- a/src/ui/hud/resource.lua
+++ b/src/ui/hud/resource.lua
@@ -5,10 +5,8 @@ local Resources = objects.Class("g.hud:Resources")
 Resources._moneyFont = love.graphics.newFont("assets/fonts/Smart 9h.ttf", 32, "mono")
 Resources._resourceFont = love.graphics.newFont("assets/fonts/Smart 9h.ttf", 24, "mono")
 
----@alias g.hud._ResourceKind "money"|"logs"|"rocks"|"bones"
-
 ---@class g.hud._ResourceParticle
----@field package kind g.hud._ResourceKind
+---@field package kind g.ResourceType
 ---@field package amount integer
 ---@field package image string
 ---@field package tokenAngle number (angle between x,y and token position)
@@ -32,23 +30,18 @@ local PARTICLE_SPAWN_CATEGORY = {
     money = {
         format = "money_particle_%d",
         counts = {1, 10, 100, 1000},
-        -- Note: g is not yet defined when this file is loaded
-        getter = function() return g.getMoney() end,
     },
     logs = {
         format = "log_particle_%d",
         counts = {1, 10, 100},
-        getter = function() return g.getLogs() end,
     },
     rocks = {
         format = "rock_particle_%d",
         counts = {1, 10},
-        getter = function() return g.getRocks() end,
     },
     bones = {
         format = "bone_particle_%d",
         counts = {1, 10, 100},
-        getter = function() return g.getBones() end
     },
 }
 local AROUND_TOKEN_RADIUS = 10
@@ -64,6 +57,7 @@ local EASINGS = {
     function(x) return -(math.cos(math.pi * x) - 1) / 2 end
 }
 
+---@type g.ResourceType[]
 local RESOURCE_KIND_LIST = {"money", "logs", "rocks", "bones"}
 
 function Resources:init()
@@ -111,7 +105,7 @@ function Resources:update(dt)
     end
 
     for _, kind in ipairs(RESOURCE_KIND_LIST) do
-        local truthValue = PARTICLE_SPAWN_CATEGORY[kind].getter()
+        local truthValue = g.getResource(kind)
         -- If truth value is less than the display value, reset.
         self.displayValue[kind] = math.min(self.displayValue[kind], truthValue)
         self.timeSinceChanged[kind] = self.timeSinceChanged[kind] + dt
@@ -262,7 +256,7 @@ local function choice(tab, rng)
     return tab[rng(#tab)]
 end
 
----@param kind g.hud._ResourceKind
+---@param kind g.ResourceType
 ---@param tier integer
 ---@param x number
 ---@param y number
@@ -304,19 +298,19 @@ function Resources:_spawnParticleImpl(kind, tier, x, y, amount)
 end
 
 ---From 0 to 1.
----@param kind g.hud._ResourceKind
+---@param kind g.ResourceType
 function Resources:_getInterpolationTime(kind)
     return math.min(self.timeSinceChanged[kind] / PARTICLE_HUD_VISUAL_ATTENTION_DURATION, 1)
 end
 
----@param kind g.hud._ResourceKind
+---@param kind g.ResourceType
 ---@param amount integer
 function Resources:_animateHudFor(kind, amount)
-    self.displayValue[kind] = math.min(self.displayValue[kind] + amount, PARTICLE_SPAWN_CATEGORY[kind].getter())
+    self.displayValue[kind] = math.min(self.displayValue[kind] + amount, g.getResource(kind))
     self.timeSinceChanged[kind] = 0
 end
 
----@param kind g.hud._ResourceKind
+---@param kind g.ResourceType
 ---@param x number Position of the token in world-space.
 ---@param y number Position of the token in world-space.
 ---@param amount number Amount to add to the display once it's done.

--- a/src/ui/hud/resource.lua
+++ b/src/ui/hud/resource.lua
@@ -240,8 +240,7 @@ function Resources:drawParticles(camera)
                 scale = 1
             end
 
-            local sx, sy = camera:toScreen(x, y)
-            g.drawImage(particle.image, sx, sy, 0, scale)
+            g.drawImage(particle.image, x, y, 0, scale)
         end
     end
 end
@@ -249,7 +248,9 @@ end
 ---@param camera Camera
 function Resources:draw(camera)
     self:drawHUD(camera)
-    return self:drawParticles(camera)
+    camera:attach()
+    self:drawParticles(camera)
+    camera:detach()
 end
 
 ---@generic T

--- a/src/ui/hud/resource.lua
+++ b/src/ui/hud/resource.lua
@@ -32,18 +32,23 @@ local PARTICLE_SPAWN_CATEGORY = {
     money = {
         format = "money_particle_%d",
         counts = {1, 10, 100, 1000},
+        -- Note: g is not yet defined when this file is loaded
+        getter = function() return g.getMoney() end,
     },
     logs = {
         format = "log_particle_%d",
         counts = {1, 10, 100},
+        getter = function() return g.getLogs() end,
     },
     rocks = {
         format = "rock_particle_%d",
         counts = {1, 10},
+        getter = function() return g.getRocks() end,
     },
     bones = {
         format = "bone_particle_%d",
         counts = {1, 10, 100},
+        getter = function() return g.getBones() end
     },
 }
 local AROUND_TOKEN_RADIUS = 10
@@ -71,25 +76,19 @@ function Resources:init()
         rocks = {0, 0},
         bones = {0, 0},
     }
-    -- Initial value
-    self.displayValueBefore = {
+    -- Shown value
+    self.displayValue = {
         money = 0,
         logs = 0,
         rocks = 0,
         bones = 0,
     }
-    -- Target value
-    self.displayValueAfter = {
-        money = 0,
-        logs = 0,
-        rocks = 0,
-        bones = 0,
-    }
+    -- Animation interpolation (e.g. increasing text scale)
     self.interpolateTime = {
-        money = 0,
-        logs = 0,
-        rocks = 0,
-        bones = 0,
+        money = PARTICLE_HUD_VISUAL_ATTENTION_DURATION,
+        logs = PARTICLE_HUD_VISUAL_ATTENTION_DURATION,
+        rocks = PARTICLE_HUD_VISUAL_ATTENTION_DURATION,
+        bones = PARTICLE_HUD_VISUAL_ATTENTION_DURATION,
     }
 end
 
@@ -112,10 +111,10 @@ function Resources:update(dt)
     end
 
     for _, kind in ipairs(RESOURCE_KIND_LIST) do
-        self.interpolateTime[kind] = math.max(self.interpolateTime[kind] - dt, 0)
-        if self.interpolateTime[kind] <= 0 then
-            self.displayValueBefore[kind] = self.displayValueAfter[kind]
-        end
+        local truthValue = PARTICLE_SPAWN_CATEGORY[kind].getter()
+        -- If truth value is less than the display value, reset.
+        self.displayValue[kind] = math.min(self.displayValue[kind], truthValue)
+        self.interpolateTime[kind] = math.min(self.interpolateTime[kind] + dt, PARTICLE_HUD_VISUAL_ATTENTION_DURATION)
     end
 end
 
@@ -169,8 +168,8 @@ function Resources:drawHUD(camera)
     love.graphics.setColor(1, 1, 0)
     love.graphics.rectangle("line", moneyR:get())
     love.graphics.setColor(0, 0, 0)
-    local value, t = self:_getDisplayValueFor("money")
-    printTextAt("$"..g.formatNumber(value), self._moneyFont, moneyR, "center", 1 + easeInCubic(t) * 0.5)
+    local t = self:_getInterpolationTime("money")
+    printTextAt("$"..g.formatNumber(self.displayValue.money), self._moneyFont, moneyR, "center", 1 + easeInCubic(1 - t) * 0.5)
 
     -- Prepare resource layout
     local logsR, rocksR, bonesR = resourcesR:splitVertical(1, 1, 1)
@@ -180,12 +179,12 @@ function Resources:drawHUD(camera)
 
     -- Draw resource text
     love.graphics.setColor(1, 1, 1)
-    value, t = self:_getDisplayValueFor("logs")
-    printTextAt(g.formatNumber(value), self._resourceFont, logsTextR, "left", 1 + easeInCubic(t) * 0.5)
-    value, t = self:_getDisplayValueFor("rocks")
-    printTextAt(g.formatNumber(value), self._resourceFont, rocksTextR, "left", 1 + easeInCubic(t) * 0.5)
-    value, t = self:_getDisplayValueFor("bones")
-    printTextAt(g.formatNumber(value), self._resourceFont, bonesTextR, "left", 1 + easeInCubic(t) * 0.5)
+    t = self:_getInterpolationTime("logs")
+    printTextAt(g.formatNumber(self.displayValue.logs), self._resourceFont, logsTextR, "left", 1 + easeInCubic(1 - t) * 0.5)
+    t = self:_getInterpolationTime("rocks")
+    printTextAt(g.formatNumber(self.displayValue.rocks), self._resourceFont, rocksTextR, "left", 1 + easeInCubic(1 - t) * 0.5)
+    t = self:_getInterpolationTime("bones")
+    printTextAt(g.formatNumber(self.displayValue.bones), self._resourceFont, bonesTextR, "left", 1 + easeInCubic(1 - t) * 0.5)
 
     -- Draw resource icon
     local icx, icy = logsIconR:getCenter()
@@ -253,22 +252,6 @@ function Resources:draw(camera)
     return self:drawParticles(camera)
 end
 
-function Resources:reset()
-    if not g.getSn() then return end
-
-    self.displayValueAfter.money = g.getMoney()
-    self.displayValueAfter.logs = g.getLogs()
-    self.displayValueAfter.rocks = g.getRocks()
-    self.displayValueAfter.bones = g.getBones()
-
-    for _, kind in ipairs(RESOURCE_KIND_LIST) do
-        self.displayValueBefore[kind] = self.displayValueAfter[kind]
-        self.interpolateTime[kind] = 0
-    end
-
-    self.particles = {}
-end
-
 ---@generic T
 ---@param tab T[] Table to pick elements of.
 ---@param rng (fun(max:integer):integer)? Function that returns random number from 1 to `max` both inclusive.
@@ -285,6 +268,13 @@ end
 ---@param amount integer
 ---@private
 function Resources:_spawnParticleImpl(kind, tier, x, y, amount)
+    local smallAmount = 0
+    -- 20% chance to spawn 1 additional smaller particles
+    if tier > 1 and love.math.random() < 0.2 then
+        smallAmount = math.ceil(amount * 0.9)
+        amount = amount - smallAmount
+    end
+
     local category = PARTICLE_SPAWN_CATEGORY[kind]
 
     local angle = math.rad(love.math.random() * 360)
@@ -307,25 +297,22 @@ function Resources:_spawnParticleImpl(kind, tier, x, y, amount)
         tohudTime = lerp(TOHUD_ANIMATION_DURATION[1], TOHUD_ANIMATION_DURATION[2], love.math.random())
     }
 
-    -- 20% chance to spawn 1 additional cosmetic particles
-    if tier > 1 and love.math.random() < 0.2 then
-        self:_spawnParticleImpl(kind, tier - 1, x, y, 0)
+    if smallAmount > 0 then
+        return self:_spawnParticleImpl(kind, tier - 1, x, y, smallAmount)
     end
 end
 
+---From 0 to 1.
 ---@param kind g.hud._ResourceKind
-function Resources:_getDisplayValueFor(kind)
-    local t = self.interpolateTime[kind] / PARTICLE_HUD_VISUAL_ATTENTION_DURATION
-    local easeT = easeInCubic(t)
-    return math.ceil(lerp(self.displayValueAfter[kind], self.displayValueBefore[kind], easeT)), t
+function Resources:_getInterpolationTime(kind)
+    return self.interpolateTime[kind] / PARTICLE_HUD_VISUAL_ATTENTION_DURATION
 end
 
 ---@param kind g.hud._ResourceKind
----@param incramount integer
-function Resources:_animateHudFor(kind, incramount)
-    self.displayValueBefore[kind] = self:_getDisplayValueFor(kind)
-    self.displayValueAfter[kind] = self.displayValueAfter[kind] + incramount
-    self.interpolateTime[kind] = PARTICLE_HUD_VISUAL_ATTENTION_DURATION
+---@param amount integer
+function Resources:_animateHudFor(kind, amount)
+    self.displayValue[kind] = math.min(self.displayValue[kind] + amount, PARTICLE_SPAWN_CATEGORY[kind].getter())
+    self.interpolateTime[kind] = 0
 end
 
 ---@param kind g.hud._ResourceKind

--- a/src/ui/hud/resource.lua
+++ b/src/ui/hud/resource.lua
@@ -83,8 +83,8 @@ function Resources:init()
         rocks = 0,
         bones = 0,
     }
-    -- Animation interpolation (e.g. increasing text scale)
-    self.interpolateTime = {
+    -- Used for animation interpolation (e.g. increasing text scale)
+    self.timeSinceChanged = {
         money = PARTICLE_HUD_VISUAL_ATTENTION_DURATION,
         logs = PARTICLE_HUD_VISUAL_ATTENTION_DURATION,
         rocks = PARTICLE_HUD_VISUAL_ATTENTION_DURATION,
@@ -114,7 +114,7 @@ function Resources:update(dt)
         local truthValue = PARTICLE_SPAWN_CATEGORY[kind].getter()
         -- If truth value is less than the display value, reset.
         self.displayValue[kind] = math.min(self.displayValue[kind], truthValue)
-        self.interpolateTime[kind] = math.min(self.interpolateTime[kind] + dt, PARTICLE_HUD_VISUAL_ATTENTION_DURATION)
+        self.timeSinceChanged[kind] = self.timeSinceChanged[kind] + dt
     end
 end
 
@@ -306,14 +306,14 @@ end
 ---From 0 to 1.
 ---@param kind g.hud._ResourceKind
 function Resources:_getInterpolationTime(kind)
-    return self.interpolateTime[kind] / PARTICLE_HUD_VISUAL_ATTENTION_DURATION
+    return math.min(self.timeSinceChanged[kind] / PARTICLE_HUD_VISUAL_ATTENTION_DURATION, 1)
 end
 
 ---@param kind g.hud._ResourceKind
 ---@param amount integer
 function Resources:_animateHudFor(kind, amount)
     self.displayValue[kind] = math.min(self.displayValue[kind] + amount, PARTICLE_SPAWN_CATEGORY[kind].getter())
-    self.interpolateTime[kind] = 0
+    self.timeSinceChanged[kind] = 0
 end
 
 ---@param kind g.hud._ResourceKind

--- a/src/world/world.lua
+++ b/src/world/world.lua
@@ -181,11 +181,6 @@ local function getTokRotation(tok)
         rot = rot + (TOKEN_DAMAGE_JERK_DURATION - tsd) * TOKEN_DAMAGE_JERK_AMPLITUDE
     end
 
-    -- local tsh = tok.timeSinceHitStart
-    -- if tsh < TOKEN_DAMAGE_JERK_DURATION then
-    --     rot = rot + (TOKEN_HIT_ANIMATION_DURATION - tsh) * TOKEN_HIT_JERK_AMPLITUDE
-    -- end
-
     if tok.id % 2 == 0 then
         return -rot
     end

--- a/src/world/world.lua
+++ b/src/world/world.lua
@@ -103,10 +103,12 @@ local function updateToken(tok,dt)
     tok.timeAlive = tok.timeAlive + dt
     tok.timeSinceDamaged = tok.timeSinceDamaged + dt
     tok.timeSinceHitStart = tok.timeSinceHitStart + dt
+    tok.timeSinceHit = tok.timeSinceHit + dt
 
-    if tok.timeSinceHitStart >= getAxeSwingTime() and tok.timeSinceHitStart < tok.timeSinceDamaged then
+    if tok.timeSinceHitStart >= getAxeSwingTime() and tok.timeSinceHitStart < tok.timeSinceHit then
         -- Damage token
         local hitMult = g.ask("getTokenHitMultiplier", tok)
+        tok.timeSinceHit = 0
         g.call("tokenHit", tok)
         g.damageToken(tok, hitMult * g.stats.HitDamage)
     end

--- a/src/world/world.lua
+++ b/src/world/world.lua
@@ -88,6 +88,9 @@ function World:_enableMouseHarvester(x,y)
 end
 
 
+local function getSwingTime()
+    return g.stats.HitDuration * 0.75
+end
 
 
 ---@param tok g.Token
@@ -96,6 +99,13 @@ local function updateToken(tok,dt)
     tok.timeAlive = tok.timeAlive + dt
     tok.timeSinceDamaged = tok.timeSinceDamaged + dt
     tok.timeSinceHitStart = tok.timeSinceHitStart + dt
+
+    if tok.timeSinceHitStart >= getSwingTime() and tok.timeSinceHitStart < tok.timeSinceDamaged then
+        -- Damage token
+        local hitMult = g.ask("getTokenHitMultiplier", tok)
+        g.call("tokenHit", tok)
+        g.damageToken(tok, hitMult * g.stats.HitDamage)
+    end
 end
 
 
@@ -199,9 +209,6 @@ end
 
 
 
-local function getSwingTime()
-    return g.stats.HitDuration * 0.75
-end
 
 
 ---@param tok g.Token

--- a/src/world/world.lua
+++ b/src/world/world.lua
@@ -95,7 +95,7 @@ end
 local function updateToken(tok,dt)
     tok.timeAlive = tok.timeAlive + dt
     tok.timeSinceDamaged = tok.timeSinceDamaged + dt
-    tok.timeSinceHit = tok.timeSinceHit + dt
+    tok.timeSinceHitStart = tok.timeSinceHitStart + dt
 end
 
 
@@ -141,7 +141,7 @@ local function getTokScale(tok)
         sy = v*1.2
     end
 
-    local tsh = tok.timeSinceHit
+    local tsh = tok.timeSinceHitStart
     if tsh < TOKEN_HIT_ANIMATION_DURATION then
         -- Make it look "squashed" down
         local mag = (TOKEN_HIT_ANIMATION_DURATION - tsh)*TOKEN_HIT_SQUASH_AMOUNT
@@ -167,7 +167,7 @@ local function getTokRotation(tok)
         rot = rot + (TOKEN_DAMAGE_JERK_DURATION - tsd) * TOKEN_DAMAGE_JERK_AMPLITUDE
     end
 
-    local tsh = tok.timeSinceHit
+    local tsh = tok.timeSinceHitStart
     if tsh < TOKEN_DAMAGE_JERK_DURATION then
         rot = rot + (TOKEN_HIT_ANIMATION_DURATION - tsh) * TOKEN_HIT_JERK_AMPLITUDE
     end
@@ -207,7 +207,7 @@ end
 ---@param tok g.Token
 local function drawAxe(tok)
     love.graphics.setColor(1,1,1)
-    local tsh = tok.timeSinceHit
+    local tsh = tok.timeSinceHitStart
     local t = (tsh - getSwingTime()) / getSwingTime()
     g.drawImage("iron_axe", tok.x - 10, tok.y - 10, t)
 end
@@ -226,7 +226,8 @@ function World:_draw()
 
     -- draw pickaxes/axes:
     for _,tok in ipairs(self.tokens) do
-        if tok.timeSinceHit < getSwingTime() then
+        ---@cast tok g.Token
+        if tok.timeSinceHitStart < getSwingTime() then
             drawAxe(tok)
         end
     end

--- a/src/world/world.lua
+++ b/src/world/world.lua
@@ -92,6 +92,10 @@ local function getSwingTime()
     return g.stats.HitDuration * 0.75
 end
 
+local function getAxeSwingTime()
+    return getSwingTime() / 2
+end
+
 
 ---@param tok g.Token
 ---@param dt number
@@ -100,7 +104,7 @@ local function updateToken(tok,dt)
     tok.timeSinceDamaged = tok.timeSinceDamaged + dt
     tok.timeSinceHitStart = tok.timeSinceHitStart + dt
 
-    if tok.timeSinceHitStart >= getSwingTime() and tok.timeSinceHitStart < tok.timeSinceDamaged then
+    if tok.timeSinceHitStart >= getAxeSwingTime() and tok.timeSinceHitStart < tok.timeSinceDamaged then
         -- Damage token
         local hitMult = g.ask("getTokenHitMultiplier", tok)
         g.call("tokenHit", tok)
@@ -151,10 +155,10 @@ local function getTokScale(tok)
         sy = v*1.2
     end
 
-    local tsh = tok.timeSinceHitStart
-    if tsh < TOKEN_HIT_ANIMATION_DURATION then
+    local tsd = tok.timeSinceDamaged
+    if tsd < TOKEN_HIT_ANIMATION_DURATION then
         -- Make it look "squashed" down
-        local mag = (TOKEN_HIT_ANIMATION_DURATION - tsh)*TOKEN_HIT_SQUASH_AMOUNT
+        local mag = (TOKEN_HIT_ANIMATION_DURATION - tsd)*TOKEN_HIT_SQUASH_AMOUNT
         sx = sx * (1+mag)
         sy = sy * (1+mag)
     end
@@ -177,10 +181,10 @@ local function getTokRotation(tok)
         rot = rot + (TOKEN_DAMAGE_JERK_DURATION - tsd) * TOKEN_DAMAGE_JERK_AMPLITUDE
     end
 
-    local tsh = tok.timeSinceHitStart
-    if tsh < TOKEN_DAMAGE_JERK_DURATION then
-        rot = rot + (TOKEN_HIT_ANIMATION_DURATION - tsh) * TOKEN_HIT_JERK_AMPLITUDE
-    end
+    -- local tsh = tok.timeSinceHitStart
+    -- if tsh < TOKEN_DAMAGE_JERK_DURATION then
+    --     rot = rot + (TOKEN_HIT_ANIMATION_DURATION - tsh) * TOKEN_HIT_JERK_AMPLITUDE
+    -- end
 
     if tok.id % 2 == 0 then
         return -rot
@@ -214,9 +218,8 @@ end
 ---@param tok g.Token
 local function drawAxe(tok)
     love.graphics.setColor(1,1,1)
-    local tsh = tok.timeSinceHitStart
-    local t = (tsh - getSwingTime()) / getSwingTime()
-    g.drawImage("iron_axe", tok.x - 10, tok.y - 10, t)
+    local t = math.min(tok.timeSinceHitStart / getAxeSwingTime(), 1)
+    g.drawImageOffset("iron_axe", tok.x - 14, tok.y + 4, t * t - 0.9, 1, 1, 0.1, 0.9)
 end
 
 


### PR DESCRIPTION
* Improved visual for axe swing.
* Token is now damaged after the axe swings.
* Resource HUD no longer lerp the values.
* Resource HUD particle now renders at correct scale even when harvest area is zoomed.

Since token is now damaged **after** axe swings, there's some changes to the EV-bus.
* `tokenHit` is now triggered once token is _about_ to be damaged instead when `g.tryHitToken` is called.
* `tokenHitStart` is now triggered when "token hit" is initiated.
* So now the EV-bus sequence is `tokenHitStart` -> `tokenHit` -> `tokenDamaged` -> (if necessary) `tokenDestroyed`.