### PR TITLE
Move Upgrade Position and Prestige

### DIFF
--- a/src/g.lua
+++ b/src/g.lua
@@ -943,6 +943,21 @@ end
 
 
 
+---@param prestige integer
+---@return fun():({x:integer,y:integer},string)
+function g.iterateUpgradeTree(prestige)
+    return coroutine.wrap(function()
+        for k, v in pairs(upgradePositionByPrestige[prestige]) do
+            for _, pos in ipairs(v) do
+                coroutine.yield({x = pos[1], y = pos[2]}, k)
+            end
+        end
+    end)
+end
+
+
+
+
 ---@param uinfo g.UpgradeInfo
 ---@return boolean
 function g.isUpgradeHidden(uinfo)

--- a/src/g.lua
+++ b/src/g.lua
@@ -679,6 +679,15 @@ end
 
 
 
+--------------------------------------------------
+-- Upgrades.
+--- 
+-- g.getUpgradeInfo(upgradeId)
+-- g.getUpgradeLevel(uinfo)
+-- g.isUpgradeLocked(uinfo)
+-- g.isUpgradeHidden(uinfo)
+--------------------------------------------------
+do
 
 -- Dont ask me how this hash/unhash shit works, i vibecoded it.
 -- (And YES, i tested it thoroughly)
@@ -713,18 +722,6 @@ end
 local function assertSmallEnough(x)
     assert(math.abs(x) < MAX_VAL, "Needs to be less than " .. MAX_VAL .. " for hashing to work correctly!")
 end
-
-
-
---------------------------------------------------
--- Upgrades.
---- 
--- g.getUpgradeInfo(upgradeId)
--- g.getUpgradeLevel(uinfo)
--- g.isUpgradeLocked(uinfo)
--- g.isUpgradeHidden(uinfo)
---------------------------------------------------
-do
 
 ---@type string[]
 g.UPGRADE_LIST = {}

--- a/src/g.lua
+++ b/src/g.lua
@@ -737,9 +737,8 @@ local upgradePositionsHash = {--[[
 ]]}
 ---@cast upgradePositionsHash {[number]: string?}
 
----The mapping is `positions: [number,number][] = t[prestige+1][upgradename]`
----Note that prestige numbering here is 1-based!!!
----@type table<string, [integer, integer][]>[]
+---The mapping is `positions: [number,number][] = t[prestige][upgradename]`
+---@type table<integer, table<string, [integer, integer][]>>
 local upgradePositionByPrestige = {}
 
 -- Load prestiges
@@ -764,7 +763,7 @@ do
                 upgradePositionsHash[hash(upos.x, upos.y, i)] = upos.type
             end
 
-            upgradePositionByPrestige[#upgradePositionByPrestige+1] = upgradePoses
+            upgradePositionByPrestige[i] = upgradePoses
         else
             break
         end
@@ -918,7 +917,7 @@ end
 ---@param uinfo g.UpgradeInfo
 ---@param prestige integer
 function g.isUpgradeDefinedInPrestige(uinfo, prestige)
-    return not not upgradePositionByPrestige[prestige + 1][uinfo.type]
+    return not not upgradePositionByPrestige[prestige][uinfo.type]
 end
 
 
@@ -931,7 +930,7 @@ function g.getUpgradePositions(uinfo, prestige)
         error("upgrade '"..uinfo.type.."' not defined in prestige "..prestige)
     end
 
-    return upgradePositionByPrestige[prestige + 1][uinfo.type]
+    return upgradePositionByPrestige[prestige][uinfo.type]
 end
 
 ---@param uinfo g.UpgradeInfo

--- a/src/g.lua
+++ b/src/g.lua
@@ -449,11 +449,8 @@ local UPGRADE_KINDS = {TOKEN=true,HARVESTING=true,TOKEN_MODIFIER=true,MISC=true}
 ---| "MISC"
 
 ---@class g.UpgradeDefinition
----@field prestige number|g.PrestigeRange
 ---@field kind g.UpgradeKind
 ---@field tokenType string? (only for kind == "TOKEN")
----@field x number
----@field y number
 ---@field price g.Bundle
 ---@field maxLevel integer?
 ---@field startingUpgrade boolean? starting-upgrades will be visible at the start, no matter what.
@@ -683,53 +680,6 @@ end
 
 
 
-
-
-
---------------------------------------------------
--- Upgrades.
---- 
--- g.getUpgradeInfo(upgradeId)
--- g.getUpgradeLevel(uinfo)
--- g.isUpgradeLocked(uinfo)
--- g.isUpgradeHidden(uinfo)
---------------------------------------------------
-do
-
----@type string[]
-g.UPGRADE_LIST = {}
-
-
----@type {[string]: g.UpgradeInfo?}
-local upgradeInfos = {--[[
-    [upgradeId] -> Table (contains all info)
-]]}
-
----@type {[number]: g.UpgradeInfo?}
-local upgradePositions = {--[[
-    hash(x,y,prestige) -> UpgradeInfo
-]]}
-
-
-
-
----@param id string
----@param name string
----@param def { token: g.TokenDefinition, upgrade: g.UpgradeDefinition|{type:nil,kind:nil} }
-function g.defineTokenUpgrade(id, name, def)
-    def.upgrade.populateTokenPool = function(self, level, tokens) ---@diagnostic disable-line
-        tokens:add(id, level)
-    end
-
-    def.upgrade.kind = "TOKEN"
-    g.defineUpgrade(id, name, def.upgrade)
-    g.defineToken(id, name, def.token)
-end
-
-
-
-
-
 -- Dont ask me how this hash/unhash shit works, i vibecoded it.
 -- (And YES, i tested it thoroughly)
 -- just make sure args are in range.
@@ -766,13 +716,98 @@ end
 
 
 
+--------------------------------------------------
+-- Upgrades.
+--- 
+-- g.getUpgradeInfo(upgradeId)
+-- g.getUpgradeLevel(uinfo)
+-- g.isUpgradeLocked(uinfo)
+-- g.isUpgradeHidden(uinfo)
+--------------------------------------------------
+do
+
+---@type string[]
+g.UPGRADE_LIST = {}
+
+
+---@type {[string]: g.UpgradeInfo?}
+local upgradeInfos = {--[[
+    [upgradeId] -> Table (contains all info)
+]]}
+
+local upgradePositionsHash = {--[[
+    hash(x,y,prestige) -> upgrade type
+]]}
+---@cast upgradePositionsHash {[number]: string?}
+
+---The mapping is `positions: [number,number][] = t[prestige+1][upgradename]`
+---Note that prestige numbering here is 1-based!!!
+---@type table<string, [integer, integer][]>[]
+local upgradePositionByPrestige = {}
+
+-- Load prestiges
+do
+    local i = 0
+    while true do
+        local p = "src/upgrades/prestige_"..i..".json"
+        if love.filesystem.getInfo(p, "file") then
+            log.trace("Loading upgrade prestige position:", p)
+            ---@type _dev.UpgradePosition[]
+            local ulist = json.decode((assert(love.filesystem.read(p))))
+            local upgradePoses = {}
+
+            for _, upos in ipairs(ulist) do
+                local positions = upgradePoses[upos.type]
+                if not positions then
+                    positions = {}
+                    upgradePoses[upos.type] = positions
+                end
+                positions[#positions+1] = {upos.x, upos.y}
+
+                upgradePositionsHash[hash(upos.x, upos.y, i)] = upos.type
+            end
+
+            upgradePositionByPrestige[#upgradePositionByPrestige+1] = upgradePoses
+        else
+            break
+        end
+
+        i = i + 1
+    end
+end
+
+
+
+---@param id string
+---@param name string
+---@param def { token: g.TokenDefinition, upgrade: g.UpgradeDefinition|{type:nil,kind:nil} }
+function g.defineTokenUpgrade(id, name, def)
+    def.upgrade.populateTokenPool = function(self, level, tokens) ---@diagnostic disable-line
+        tokens:add(id, level)
+    end
+
+    def.upgrade.kind = "TOKEN"
+    g.defineUpgrade(id, name, def.upgrade)
+    g.defineToken(id, name, def.token)
+end
+
+
+
+
+
+
+
 ---@param uinfo g.UpgradeInfo
 ---@param prestige number
----@return g.UpgradeInfo
 local function getNeighbor(uinfo, prestige, dx,dy)
-    local ux, uy = uinfo.x+dx, uinfo.y+dy
+    local upos = g.getUpgradePosition(uinfo, prestige)
+    local ux, uy = upos[1]+dx, upos[2]+dy
     local h = hash(ux,uy,prestige)
-    return upgradePositions[h]
+    local utype = upgradePositionsHash[h]
+    if utype then
+        return g.getUpgradeInfo(utype)
+    end
+    return nil
 end
 
 
@@ -836,15 +871,7 @@ function g.defineUpgrade(id, name, def)
     table.insert(g.UPGRADE_LIST, id)
 
     niceAssert(type(id) == "string")
-    niceAssert(type(def.prestige) == "number", "Invalid prestige: ", def.prestige)
     niceAssert(g.isImage(def.image), "Invalid image: ", def.image)
-    niceAssert(type(def.x) == "number" and type(def.y) == "number", "Upgrades needs x,y coords")
-
-    assertSmallEnough(def.x)
-    assertSmallEnough(def.y)
-    assertSmallEnough(def.prestige)
-
-    upgradePositions[hash(def.x,def.y,def.prestige)] = def
 
     def.type = id
 
@@ -891,12 +918,39 @@ function g.isUpgradeLocked(uinfo)
 end
 
 
+---@param uinfo g.UpgradeInfo
+---@param prestige integer
+function g.isUpgradeDefinedInPrestige(uinfo, prestige)
+    return not not upgradePositionByPrestige[prestige + 1][uinfo.type]
+end
+
+
+
+---@param uinfo g.UpgradeInfo
+---@param prestige integer
+---@return [number, number][]
+function g.getUpgradePositions(uinfo, prestige)
+    if not g.isUpgradeDefinedInPrestige(uinfo, prestige) then
+        error("upgrade '"..uinfo.type.."' not defined in prestige "..prestige)
+    end
+
+    return upgradePositionByPrestige[prestige + 1][uinfo.type]
+end
+
+---@param uinfo g.UpgradeInfo
+---@param prestige integer
+---@return [number, number]
+function g.getUpgradePosition(uinfo, prestige)
+    return g.getUpgradePositions(uinfo, prestige)[1]
+end
+
+
 
 
 ---@param uinfo g.UpgradeInfo
 ---@return boolean
 function g.isUpgradeHidden(uinfo)
-    if not g.inPrestigeRange(g.getPrestige(), uinfo.prestige) then
+    if not g.isUpgradeDefinedInPrestige(uinfo, g.getPrestige()) then
         -- not in prestige range... its obviously hidden
         return true
     end

--- a/src/scenes/dev_scene/dev_scene.lua
+++ b/src/scenes/dev_scene/dev_scene.lua
@@ -408,7 +408,6 @@ local function drawUpgradeSceneUI(r, cam)
         :moveUnit(-4, -4)
     love.graphics.setColor(1, 1, 1)
     richtext.printRich(helpText, font, textR.x, textR.y, textR.w, "left")
-    ui.debugRegion(r)
 end
 
 ---@param x integer

--- a/src/scenes/upgrade_scene/upgrade_scene.lua
+++ b/src/scenes/upgrade_scene/upgrade_scene.lua
@@ -17,14 +17,16 @@ upgscene.upgradeDescription = nil
 
 
 ---@param uinfo g.UpgradeInfo
+---@param prestige integer
 ---@return number
 ---@return number
 ---@return number
-local function getUpgradeCoords(uinfo)
+local function getUpgradeCoords(uinfo, prestige)
+    local upos = g.getUpgradePosition(uinfo, prestige)
     local size = consts.UPGRADE_IMAGE_SIZE
     local spacing = consts.UPGRADE_GRID_SPACING + size
-    local x = uinfo.x * spacing
-    local y = uinfo.y * spacing
+    local x = upos[1] * spacing
+    local y = upos[2] * spacing
     -- x,y is center of box
     -- `size` is size of upgrade-box
     return x,y,size
@@ -92,7 +94,7 @@ local function drawUpgradeBoxes()
         local uinfo = g.getUpgradeInfo(id)
         if not g.isUpgradeHidden(uinfo) then
             local level = g.getUpgradeLevel(uinfo)
-            local cx,cy,size = getUpgradeCoords(uinfo)
+            local cx,cy,size = getUpgradeCoords(uinfo, g.getPrestige())
             local x,y,w,h = cx-size/2, cy-size/2, size, size
 
             local isRecommended = not not (bestUpgrade and (bestUpgrade.type == uinfo.type))

--- a/src/scenes/upgrade_scene/upgrade_scene.lua
+++ b/src/scenes/upgrade_scene/upgrade_scene.lua
@@ -16,17 +16,16 @@ upgscene.upgradeDescription = nil
 
 
 
----@param uinfo g.UpgradeInfo
----@param prestige integer
+---@param tx integer
+---@param ty integer
 ---@return number
 ---@return number
 ---@return number
-local function getUpgradeCoords(uinfo, prestige)
-    local upos = g.getUpgradePosition(uinfo, prestige)
+local function getUpgradeCoords(tx, ty)
     local size = consts.UPGRADE_IMAGE_SIZE
     local spacing = consts.UPGRADE_GRID_SPACING + size
-    local x = upos[1] * spacing
-    local y = upos[2] * spacing
+    local x = tx * spacing
+    local y = ty * spacing
     -- x,y is center of box
     -- `size` is size of upgrade-box
     return x,y,size
@@ -62,7 +61,7 @@ local function getBestUpgradeType()
     local sumprice = math.huge
     local level = math.huge
 
-    for _, id in ipairs(g.UPGRADE_LIST) do
+    for _, id in g.iterateUpgradeTree(g.getPrestige()) do
         local uinfo = g.getUpgradeInfo(id)
         local price = g.getUpgradePrice(uinfo)
 
@@ -90,11 +89,11 @@ local function drawUpgradeBoxes()
     local hoveredUpgrade = nil
     local bestUpgrade = getBestUpgradeType()
 
-    for _, id in ipairs(g.UPGRADE_LIST) do
+    for pos, id in g.iterateUpgradeTree(g.getPrestige()) do
         local uinfo = g.getUpgradeInfo(id)
         if not g.isUpgradeHidden(uinfo) then
             local level = g.getUpgradeLevel(uinfo)
-            local cx,cy,size = getUpgradeCoords(uinfo, g.getPrestige())
+            local cx,cy,size = getUpgradeCoords(pos.x, pos.y)
             local x,y,w,h = cx-size/2, cy-size/2, size, size
 
             local isRecommended = not not (bestUpgrade and (bestUpgrade.type == uinfo.type))

--- a/src/upgrades/harvesting/p1_harvesting_upgrades.lua
+++ b/src/upgrades/harvesting/p1_harvesting_upgrades.lua
@@ -17,9 +17,6 @@ local X=-3
 local Y=0
 
 defUpgrade("more_damage", "More Damage", {
-    x=X,y=Y,
-    prestige=0,
-
     startingUpgrade=true,
 
     price = {money=10},
@@ -38,9 +35,6 @@ defUpgrade("more_damage", "More Damage", {
 
 
 defUpgrade("hit_speed", "Hit Speed", {
-    x=X,y=Y-1,
-    prestige=0,
-
     price = {money=10},
 
     getValues = function(self,level)
@@ -57,9 +51,6 @@ defUpgrade("hit_speed", "Hit Speed", {
 
 
 defUpgrade("more_area", "More Area", {
-    x=X-1,y=Y,
-    prestige=0,
-
     price = {money=10},
 
     getValues = function(self,level)
@@ -77,9 +68,6 @@ defUpgrade("more_area", "More Area", {
 
 
 defUpgrade("lucky_hit", "Lucky Hit", {
-    x=X,y=Y-2,
-    prestige=0,
-
     price = {money=10},
 
     getValues = function(self,level)

--- a/src/upgrades/prestige_0.json
+++ b/src/upgrades/prestige_0.json
@@ -1,0 +1,15 @@
+[
+    {"x": 1, "y": 1, "type": "grass_blades"},
+    {"x": 1, "y": 2, "type": "small_grass"},
+    {"x": 1, "y": 3, "type": "thick_grass"},
+    {"x": 2, "y": 3, "type": "bamboo"},
+    {"x": 2, "y": 1, "type": "stick"},
+    {"x": 3, "y": 1, "type": "basic_log"},
+    {"x": 2, "y": 0, "type": "happy_kitten"},
+    {"x": 2, "y": -1, "type": "happy_cat"},
+    {"x": 2, "y": -2, "type": "business_cat"},
+    {"x": -3, "y": 0, "type": "more_damage"},
+    {"x": -3, "y": -1, "type": "hit_speed"},
+    {"x": -4, "y": 0, "type": "more_area"},
+    {"x": -3, "y": -2, "type": "lucky_hit"}
+]

--- a/src/upgrades/tokens/prestige_1/basic/p1_toks.lua
+++ b/src/upgrades/tokens/prestige_1/basic/p1_toks.lua
@@ -8,9 +8,7 @@ g.defineTokenUpgrade("grass_blades", "Grass Blades", {
     },
     upgrade = {
         startingUpgrade=true,
-        prestige = 0,
         price = {money=3},
-        x=1,y=1,
     }
 })
 
@@ -22,9 +20,7 @@ g.defineTokenUpgrade("small_grass", "Small Grass", {
         maxHealth = 6
     },
     upgrade = {
-        prestige = 0,
         price = {money=5},
-        x=1,y=2,
     }
 })
 
@@ -36,9 +32,7 @@ g.defineTokenUpgrade("thick_grass", "Thick Grass", {
         maxHealth = 8
     },
     upgrade = {
-        prestige = 0,
         price = {money=10},
-        x=1,y=3,
     }
 })
 
@@ -50,9 +44,7 @@ g.defineTokenUpgrade("bamboo", "Bamboo", {
         maxHealth = 12
     },
     upgrade = {
-        prestige = 0,
         price = {money=50},
-        x=2,y=3,
     }
 })
 
@@ -70,9 +62,7 @@ g.defineTokenUpgrade("stick", "Stick", {
     },
 
     upgrade = {
-        prestige = 0,
         price = {money=10},
-        x=2,y=1,
     }
 })
 
@@ -88,9 +78,7 @@ g.defineTokenUpgrade("basic_log", "Basic Log", {
     },
 
     upgrade = {
-        prestige = 0,
         price = {money=10},
-        x=3,y=1,
     }
 })
 
@@ -98,7 +86,6 @@ g.defineTokenUpgrade("basic_log", "Basic Log", {
 
 do
 
-local X,Y = 2,0
 g.defineTokenUpgrade("happy_kitten", "Happy Kitten", {
     token = {
         resources = {
@@ -108,9 +95,7 @@ g.defineTokenUpgrade("happy_kitten", "Happy Kitten", {
     },
 
     upgrade = {
-        prestige = 0,
         price = {money=100},
-        x=X,y=Y
     }
 })
 
@@ -124,9 +109,7 @@ g.defineTokenUpgrade("happy_cat", "Happy Cat", {
     },
 
     upgrade = {
-        prestige = 0,
         price = {money = 400},
-        x = X, y = Y-1
     }
 })
 
@@ -139,9 +122,7 @@ g.defineTokenUpgrade("business_cat", "Business Cat", {
     },
 
     upgrade = {
-        prestige = 0,
         price = {money = 5000},
-        x = X, y = Y-2
     }
 })
 


### PR DESCRIPTION
This moves the position definition of an upgrade to a separate JSON file. It also adds 2 functions:
* `g.isUpgradeDefinedInPrestige(uinfo: g.UpgradeInfo, prestige: integer): boolean` check if specified upgrade exist in specified prestige.
* `g.getUpgradePosition(uinfo: g.UpgradeInfo, prestige: integer): [number,number]` queries the upgrade position of specified upgrade in the specified prestige.

Do note that currently, changes in upgrade editor devtools won't be reflected automatically in upgrade editor until game restart.